### PR TITLE
Stop gating SSL support on QT_NO_OPENSSL

### DIFF
--- a/src/core/irc.cpp
+++ b/src/core/irc.cpp
@@ -33,9 +33,7 @@
 #include "ircmessage_p.h"
 #include <QMetaEnum>
 #include <QDebug>
-#ifndef QT_NO_OPENSSL
 #include <QSslSocket>
-#endif // QT_NO_OPENSSL
 
 IRC_BEGIN_NAMESPACE
 
@@ -66,11 +64,7 @@ IRC_BEGIN_NAMESPACE
  */
 bool Irc::isSecureSupported()
 {
-#ifdef QT_NO_OPENSSL
-    return false;
-#else
     return QSslSocket::supportsSsl();
-#endif
 }
 
 /*!

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -45,10 +45,8 @@
 #include <QMetaObject>
 #include <QMetaMethod>
 #include <QMetaEnum>
-#ifndef QT_NO_OPENSSL
 #include <QSslSocket>
 #include <QSslError>
-#endif // QT_NO_OPENSSL
 #include <QDataStream>
 #include <QVariantMap>
 
@@ -313,13 +311,13 @@ void IrcConnectionPrivate::_irc_sslErrors()
 {
     Q_Q(IrcConnection);
     QStringList errors;
-#ifndef QT_NO_OPENSSL
+
     QSslSocket* ssl = qobject_cast<QSslSocket*>(socket);
     if (ssl) {
         foreach (const QSslError& error, ssl->sslErrors())
             errors += error.errorString();
     }
-#endif
+
     ircDebug(q, IrcDebug::Error) << errors;
     emit q->secureError();
 }
@@ -1177,21 +1175,11 @@ void IrcConnection::setSocket(QAbstractSocket* socket)
  */
 bool IrcConnection::isSecure() const
 {
-#ifdef QT_NO_OPENSSL
-    return false;
-#else
     return qobject_cast<QSslSocket*>(socket());
-#endif // QT_NO_OPENSSL
 }
 
 void IrcConnection::setSecure(bool secure)
 {
-#ifdef QT_NO_OPENSSL
-    if (secure) {
-        qWarning("IrcConnection::setSecure(): the Qt build does not support SSL");
-        return;
-    }
-#else
     if (secure && !QSslSocket::supportsSsl()) {
         qWarning("IrcConnection::setSecure(): the platform does not support SSL - try installing OpenSSL");
         return;
@@ -1207,7 +1195,6 @@ void IrcConnection::setSecure(bool secure)
         setSocket(new QTcpSocket(this));
         emit secureChanged(false);
     }
-#endif // !QT_NO_OPENSSL
 }
 
 /*!

--- a/tests/auto/ircconnection/tst_ircconnection.cpp
+++ b/tests/auto/ircconnection/tst_ircconnection.cpp
@@ -17,9 +17,7 @@
 #include <QtCore/QRegExp>
 #include <QtCore/QTextCodec>
 #include <QtCore/QScopedPointer>
-#ifndef QT_NO_OPENSSL
 #include <QtNetwork/QSslSocket>
-#endif
 
 #include "tst_ircdata.h"
 #include "tst_ircclientserver.h"
@@ -356,9 +354,7 @@ void tst_IrcConnection::testSocket_data()
 
     QTest::newRow("null") << static_cast<QAbstractSocket*>(0);
     QTest::newRow("tcp") << static_cast<QAbstractSocket*>(new QTcpSocket(this));
-#ifndef QT_NO_OPENSSL
     QTest::newRow("ssl") << static_cast<QAbstractSocket*>(new QSslSocket(this));
-#endif
 }
 
 void tst_IrcConnection::testSocket()
@@ -378,32 +374,18 @@ void tst_IrcConnection::testSecure()
     QVERIFY(spy.isValid());
     QVERIFY(!connection.isSecure());
 
-#ifdef QT_NO_OPENSSL
-    QTest::ignoreMessage(QtWarningMsg, "IrcConnection::setSecure(): the Qt build does not support SSL");
-#endif
-
     connection.setSecure(true);
 
-#ifndef QT_NO_OPENSSL
     QVERIFY(connection.isSecure());
     QVERIFY(connection.socket()->inherits("QSslSocket"));
     QCOMPARE(spy.count(), 1);
     QVERIFY(spy.first().first().toBool());
-#else
-    QVERIFY(!connection.isSecure());
-    QVERIFY(!connection.socket()->inherits("QSslSocket"));
-    QCOMPARE(spy.count(), 0);
-#endif
 
     connection.setSecure(false);
     QVERIFY(!connection.isSecure());
     QVERIFY(!connection.socket()->inherits("QSslSocket"));
-#ifndef QT_NO_OPENSSL
     QCOMPARE(spy.count(), 2);
     QVERIFY(!spy.last().last().toBool());
-#else
-    QCOMPARE(spy.count(), 0);
-#endif
 }
 
 void tst_IrcConnection::testSasl()
@@ -518,7 +500,6 @@ void tst_IrcConnection::testNoSasl()
     QVERIFY(written.contains("CAP END"));
 }
 
-#ifndef QT_NO_OPENSSL
 class SslSocket : public QSslSocket
 {
     Q_OBJECT
@@ -534,11 +515,9 @@ public slots:
         QSslSocket::startClientEncryption();
     }
 };
-#endif // !QT_NO_OPENSSL
 
 void tst_IrcConnection::testSsl()
 {
-#ifndef QT_NO_OPENSSL
     SslSocket* socket = new SslSocket(connection);
     connection->setSocket(socket);
     QCOMPARE(connection->socket(), socket);
@@ -547,7 +526,6 @@ void tst_IrcConnection::testSsl()
     QVERIFY(waitForOpened());
 
     QVERIFY(socket->clientEncryptionStarted);
-#endif // !QT_NO_OPENSSL
 }
 
 void tst_IrcConnection::testOpen()


### PR DESCRIPTION
On Macs, SSL is also supported through SecureTransport, but requires
building QT with `-no-openssl -securetransport` which sets the
`QT_NO_OPENSSL` flag even though `QSslSocket::supportsSsl() => true`.