### PR TITLE
Use new QT_NO_SSL flag to check SSL availability

### DIFF
--- a/src/core/irc.cpp
+++ b/src/core/irc.cpp
@@ -33,9 +33,9 @@
 #include "ircmessage_p.h"
 #include <QMetaEnum>
 #include <QDebug>
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
 #include <QSslSocket>
-#endif // QT_NO_OPENSSL
+#endif // QT_NO_SSL
 
 IRC_BEGIN_NAMESPACE
 
@@ -66,7 +66,7 @@ IRC_BEGIN_NAMESPACE
  */
 bool Irc::isSecureSupported()
 {
-#ifdef QT_NO_OPENSSL
+#ifdef QT_NO_SSL
     return false;
 #else
     return QSslSocket::supportsSsl();

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -45,10 +45,10 @@
 #include <QMetaObject>
 #include <QMetaMethod>
 #include <QMetaEnum>
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
 #include <QSslSocket>
 #include <QSslError>
-#endif // QT_NO_OPENSSL
+#endif // QT_NO_SSL
 #include <QDataStream>
 #include <QVariantMap>
 
@@ -313,7 +313,7 @@ void IrcConnectionPrivate::_irc_sslErrors()
 {
     Q_Q(IrcConnection);
     QStringList errors;
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
     QSslSocket* ssl = qobject_cast<QSslSocket*>(socket);
     if (ssl) {
         foreach (const QSslError& error, ssl->sslErrors())
@@ -1177,16 +1177,16 @@ void IrcConnection::setSocket(QAbstractSocket* socket)
  */
 bool IrcConnection::isSecure() const
 {
-#ifdef QT_NO_OPENSSL
+#ifdef QT_NO_SSL
     return false;
 #else
     return qobject_cast<QSslSocket*>(socket());
-#endif // QT_NO_OPENSSL
+#endif // QT_NO_SSL
 }
 
 void IrcConnection::setSecure(bool secure)
 {
-#ifdef QT_NO_OPENSSL
+#ifdef QT_NO_SSL
     if (secure) {
         qWarning("IrcConnection::setSecure(): the Qt build does not support SSL");
         return;
@@ -1207,7 +1207,7 @@ void IrcConnection::setSecure(bool secure)
         setSocket(new QTcpSocket(this));
         emit secureChanged(false);
     }
-#endif // !QT_NO_OPENSSL
+#endif // !QT_NO_SSL
 }
 
 /*!

--- a/tests/auto/ircconnection/tst_ircconnection.cpp
+++ b/tests/auto/ircconnection/tst_ircconnection.cpp
@@ -17,7 +17,7 @@
 #include <QtCore/QRegExp>
 #include <QtCore/QTextCodec>
 #include <QtCore/QScopedPointer>
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
 #include <QtNetwork/QSslSocket>
 #endif
 
@@ -356,7 +356,7 @@ void tst_IrcConnection::testSocket_data()
 
     QTest::newRow("null") << static_cast<QAbstractSocket*>(0);
     QTest::newRow("tcp") << static_cast<QAbstractSocket*>(new QTcpSocket(this));
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
     QTest::newRow("ssl") << static_cast<QAbstractSocket*>(new QSslSocket(this));
 #endif
 }
@@ -378,13 +378,13 @@ void tst_IrcConnection::testSecure()
     QVERIFY(spy.isValid());
     QVERIFY(!connection.isSecure());
 
-#ifdef QT_NO_OPENSSL
+#ifdef QT_NO_SSL
     QTest::ignoreMessage(QtWarningMsg, "IrcConnection::setSecure(): the Qt build does not support SSL");
 #endif
 
     connection.setSecure(true);
 
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
     QVERIFY(connection.isSecure());
     QVERIFY(connection.socket()->inherits("QSslSocket"));
     QCOMPARE(spy.count(), 1);
@@ -398,7 +398,7 @@ void tst_IrcConnection::testSecure()
     connection.setSecure(false);
     QVERIFY(!connection.isSecure());
     QVERIFY(!connection.socket()->inherits("QSslSocket"));
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
     QCOMPARE(spy.count(), 2);
     QVERIFY(!spy.last().last().toBool());
 #else
@@ -518,7 +518,7 @@ void tst_IrcConnection::testNoSasl()
     QVERIFY(written.contains("CAP END"));
 }
 
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
 class SslSocket : public QSslSocket
 {
     Q_OBJECT
@@ -534,11 +534,11 @@ public slots:
         QSslSocket::startClientEncryption();
     }
 };
-#endif // !QT_NO_OPENSSL
+#endif // !QT_NO_SSL
 
 void tst_IrcConnection::testSsl()
 {
-#ifndef QT_NO_OPENSSL
+#ifndef QT_NO_SSL
     SslSocket* socket = new SslSocket(connection);
     connection->setSocket(socket);
     QCOMPARE(connection->socket(), socket);
@@ -547,7 +547,7 @@ void tst_IrcConnection::testSsl()
     QVERIFY(waitForOpened());
 
     QVERIFY(socket->clientEncryptionStarted);
-#endif // !QT_NO_OPENSSL
+#endif // !QT_NO_SSL
 }
 
 void tst_IrcConnection::testOpen()


### PR DESCRIPTION
With QT5 support for alternative SSL backends, this new flag takes
the place of the previous `QT_NO_OPENSSL` flag for determining if
QT was bulit with support for secure connections.  This specifically
fixes support for SecureTransport on Mac.

This breaks support for QT4 builds without OpenSSL.