### PR TITLE
Revise: reduce warnings by handling some code that Qt has declared obsolete

### DIFF
--- a/examples/bot/main.cpp
+++ b/examples/bot/main.cpp
@@ -8,6 +8,9 @@
  */
 
 #include <QtCore>
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
 #include "ircbot.h"
 
 int main(int argc, char* argv[])
@@ -16,12 +19,16 @@ int main(int argc, char* argv[])
 
     // enable debug output
     qputenv("IRC_DEBUG", "1");
-    qsrand(QTime::currentTime().msec());
 
     IrcBot bot;
     bot.setHost("irc.freenode.net");
     bot.setUserName("communi");
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 10, 0))
+    bot.setNickName("Bot" + QString::number(QRandomGenerator::global()->bounded(1, 10000)));
+#else
+    qsrand(QTime::currentTime().msec());
     bot.setNickName("Bot" + QString::number(qrand() % 9999));
+#endif
     bot.setRealName("Communi " + Irc::version() + " example bot");
 
     bool joined = false;

--- a/examples/client/ircclient.cpp
+++ b/examples/client/ircclient.cpp
@@ -10,15 +10,18 @@
 #include "ircclient.h"
 #include "ircmessageformatter.h"
 
-#include <QTextDocument>
-#include <QTextCursor>
-#include <QVBoxLayout>
-#include <QScrollBar>
 #include <QLineEdit>
-#include <QShortcut>
 #include <QListView>
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
+#include <QScrollBar>
+#include <QShortcut>
+#include <QTextCursor>
+#include <QTextDocument>
 #include <QTextEdit>
 #include <QTime>
+#include <QVBoxLayout>
 
 #include <Irc>
 #include <IrcUser>
@@ -99,7 +102,11 @@ void IrcClient::onTextEntered()
         lineEdit->clear();
     } else if (input.length() > 1) {
         QString error;
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        QString command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
+#else
         QString command = lineEdit->text().mid(1).split(" ", QString::SkipEmptyParts).value(0).toUpper();
+#endif
         if (parser->commands().contains(command))
             error = tr("[ERROR] Syntax: %1").arg(parser->syntax(command).replace("<", "&lt;").replace(">", "&gt;"));
         else
@@ -312,10 +319,14 @@ void IrcClient::createConnection()
     connect(connection, SIGNAL(connecting()), this, SLOT(onConnecting()));
     connect(connection, SIGNAL(disconnected()), this, SLOT(onDisconnected()));
 
-    qsrand(QTime::currentTime().msec());
 
     connection->setHost(SERVER);
     connection->setUserName("communi");
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 10, 0))
+    connection->setNickName(tr("Client%1").arg(QRandomGenerator::global()->bounded(1, 10000)));
+#else
+    qsrand(QTime::currentTime().msec());
     connection->setNickName(tr("Client%1").arg(qrand() % 9999));
+#endif
     connection->setRealName(tr("Communi %1 example client").arg(IRC_VERSION_STR));
 }

--- a/examples/minimal/main.cpp
+++ b/examples/minimal/main.cpp
@@ -8,6 +8,9 @@
  */
 
 #include <QtCore>
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 10, 0))
+#include <QRandomGenerator>
+#endif
 #include <IrcConnection>
 #include <IrcCommand>
 #include <Irc>
@@ -19,12 +22,16 @@ int main(int argc, char* argv[])
 
     // enable debug output
     qputenv("IRC_DEBUG", "1");
-    qsrand(QTime::currentTime().msec());
 
 //! [minimal]
     IrcConnection connection("irc.freenode.net");
     connection.setUserName("communi");
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 10, 0))
+    connection.setNickName(QString("Minimal%1").arg(QRandomGenerator::global()->bounded(1, 10000)));
+#else
+    qsrand(QTime::currentTime().msec());
     connection.setNickName(QString("Minimal%1").arg(qrand() % 9999));
+#endif
     connection.setRealName(QString("Communi %1 minimal example").arg(Irc::version()));
     connection.sendCommand(IrcCommand::createJoin("#botwar"));
     connection.sendCommand(IrcCommand::createMessage("#botwar", "Hi, kthxbye!"));

--- a/src/core/ircnetwork.cpp
+++ b/src/core/ircnetwork.cpp
@@ -191,7 +191,11 @@ IrcNetworkPrivate::IrcNetworkPrivate() :
 static QHash<QString, int> numericValues(const QString& parameter)
 {
     QHash<QString, int> values;
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+    const QStringList keyValues = parameter.split(",", Qt::SkipEmptyParts);
+#else
     const QStringList keyValues = parameter.split(",", QString::SkipEmptyParts);
+#endif
     foreach (const QString& keyValue, keyValues)
         values.insert(keyValue.section(":", 0, 0), keyValue.section(":", 1, 1).toInt());
     return values;
@@ -204,13 +208,26 @@ void IrcNetworkPrivate::setInfo(const QHash<QString, QString>& info)
         setName(info.value("NETWORK"));
     if (info.contains("PREFIX")) {
         const QString pfx = info.value("PREFIX");
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        setModes(pfx.mid(1, pfx.indexOf(')') - 1).split("", Qt::SkipEmptyParts));
+        setPrefixes(pfx.mid(pfx.indexOf(')') + 1).split("", Qt::SkipEmptyParts));
+#else
         setModes(pfx.mid(1, pfx.indexOf(')') - 1).split("", QString::SkipEmptyParts));
         setPrefixes(pfx.mid(pfx.indexOf(')') + 1).split("", QString::SkipEmptyParts));
+#endif
     }
     if (info.contains("CHANTYPES"))
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        setChannelTypes(info.value("CHANTYPES").split("", Qt::SkipEmptyParts));
+#else
         setChannelTypes(info.value("CHANTYPES").split("", QString::SkipEmptyParts));
+#endif
     if (info.contains("STATUSMSG"))
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        setStatusPrefixes(info.value("STATUSMSG").split("", Qt::SkipEmptyParts));
+#else
         setStatusPrefixes(info.value("STATUSMSG").split("", QString::SkipEmptyParts));
+#endif
 
     // TODO:
     if (info.contains("NICKLEN"))
@@ -228,7 +245,11 @@ void IrcNetworkPrivate::setInfo(const QHash<QString, QString>& info)
     if (info.contains("MONITOR"))
         numericLimits.insert("MONITOR", info.value("MONITOR").toInt());
     if (info.contains("CHANMODES"))
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        channelModes = info.value("CHANMODES").split(",", Qt::SkipEmptyParts);
+#else
         channelModes = info.value("CHANMODES").split(",", QString::SkipEmptyParts);
+#endif
     if (info.contains("MAXLIST"))
         modeLimits = numericValues(info.value("MAXLIST"));
     if (info.contains("CHANLIMIT"))
@@ -512,6 +533,16 @@ QStringList IrcNetwork::channelModes(IrcNetwork::ModeTypes types) const
 {
     Q_D(const IrcNetwork);
     QStringList modes;
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+    if (types & TypeA)
+        modes += d->channelModes.value(0).split("", Qt::SkipEmptyParts);
+    if (types & TypeB)
+        modes += d->channelModes.value(1).split("", Qt::SkipEmptyParts);
+    if (types & TypeC)
+        modes += d->channelModes.value(2).split("", Qt::SkipEmptyParts);
+    if (types & TypeD)
+        modes += d->channelModes.value(3).split("", Qt::SkipEmptyParts);
+#else
     if (types & TypeA)
         modes += d->channelModes.value(0).split("", QString::SkipEmptyParts);
     if (types & TypeB)
@@ -520,6 +551,7 @@ QStringList IrcNetwork::channelModes(IrcNetwork::ModeTypes types) const
         modes += d->channelModes.value(2).split("", QString::SkipEmptyParts);
     if (types & TypeD)
         modes += d->channelModes.value(3).split("", QString::SkipEmptyParts);
+#endif
     return modes;
 }
 


### PR DESCRIPTION
As of Qt 5.15.0 I am finding that some items are producing obsolete or deprecated code warnings. Specifically:
* the `QString::SplitBehaviour` enum has been replaced by a `Qt::SplitBehaviour` one (in Qt 5.14)
* `qrand()` and `qsrand()` have been declared obsolete and the former can be replaced with methods in a `QRandomGenerator` class. Originally provided in Qt 5.10 and declared obsolete in some version after that.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>