### PR TITLE
Support more responses to CAP LS 302

### DIFF
--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -306,8 +306,25 @@ void IrcProtocolPrivate::handleCapabilityMessage(IrcCapabilityMessage* msg)
             }
             const QStringList params = msg->parameters();
             if (params.value(params.count() - 1) != QLatin1String("*")) {
-                if (!connection->saslMechanism().isEmpty() && availableCaps.contains(QLatin1String("sasl")))
-                    requestedCaps += QLatin1String("sasl");
+                if (!connection->saslMechanism().isEmpty()) {
+                    foreach (const QString& cap, availableCaps) {
+                        QStringList capParts = cap.split('=');
+                        if (capParts.length() == 2) {
+                            QString capName = capParts[0];
+                            if (capName.compare(QLatin1String("sasl"), Qt::CaseInsensitive) == 0) {
+                                // The server has advertised supporting SASL with a list of supported SASL Mechanisms, ensure our supported SASL Mechanism is part of that list before accepting the SASL capability
+                                QStringList serverSaslMethods = capParts[1].split(',');
+                                if (serverSaslMethods.contains(connection->saslMechanism())) {
+                                    requestedCaps += QLatin1String("sasl");
+                                }
+                            }
+                        } else {
+                            if (cap.compare(QLatin1String("sasl"), Qt::CaseInsensitive) == 0) {
+                                requestedCaps += QLatin1String("sasl");
+                            }
+                        }
+                    }
+                }
             }
             if (!requestedCaps.isEmpty())
                 connection->sendRaw("CAP REQ :" + QStringList(IrcPrivate::setToList(requestedCaps)).join(" "));

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -318,10 +318,8 @@ void IrcProtocolPrivate::handleCapabilityMessage(IrcCapabilityMessage* msg)
                                     requestedCaps += QLatin1String("sasl");
                                 }
                             }
-                        } else {
-                            if (cap.compare(QLatin1String("sasl"), Qt::CaseInsensitive) == 0) {
-                                requestedCaps += QLatin1String("sasl");
-                            }
+                        } else if (cap.compare(QLatin1String("sasl"), Qt::CaseInsensitive) == 0) {
+                            requestedCaps += QLatin1String("sasl");
                         }
                     }
                 }

--- a/tests/auto/ircnetwork/tst_ircnetwork.cpp
+++ b/tests/auto/ircnetwork/tst_ircnetwork.cpp
@@ -226,6 +226,22 @@ void tst_IrcNetwork::testCapabilities_data()
                                << QString("sasl identify-msg multi-prefix") // available
                                << QString("sasl"); // active
 
+    QTest::newRow("sasl mech") << QString("multi-prefix sasl=PLAIN,EXTERNAL identify-msg") // initial
+                               << QString("sasl") // requested
+                               << QString("sasl") // acked
+                               << QString() // naked
+                               << QString("sasl=PLAIN,EXTERNAL identify-msg multi-prefix") // listed
+                               << QString("sasl=PLAIN,EXTERNAL identify-msg multi-prefix") // available
+                               << QString("sasl"); // active
+
+    QTest::newRow("saslnmech") << QString("multi-prefix sasl=EXTERNAL identify-msg") // initial
+                               << QString("") // requested
+                               << QString("") // acked
+                               << QString() // naked
+                               << QString("sasl=EXTERNAL identify-msg multi-prefix") // listed
+                               << QString("sasl=EXTERNAL identify-msg multi-prefix") // available
+                               << QString(""); // active
+
     QTest::newRow("unk")       << QString("multi-prefix sasl identify-msg") // initial
                                << QString("unk") // requested
                                << QString() // acked


### PR DESCRIPTION
Previously, a simple "contains" was run on the response to `CAP LS 302`,
    however, some servers responded with which SASL mechanisms were
    supported, which caused the contains check to break.
See https://ircv3.net/specs/core/capability-negotiation.html#cap-ls-version

This has been actively tested with the `oragono` IRC server

Tests have been added, however I'm not sure if it's reasonable for the `listed` and `available` sasl to completely duplicate the cap sent in initial (so `sasl=PLAIN,EXTERNAL` in this test) or if it should be only `sasl` here