### PR TITLE
Make sure to remove buffer from channel list when buffer get destroyed

### DIFF
--- a/include/IrcModel/ircbuffer.h
+++ b/include/IrcModel/ircbuffer.h
@@ -62,6 +62,14 @@ class IRC_MODEL_EXPORT IrcBuffer : public QObject
     Q_PROPERTY(QVariantMap userData READ userData WRITE setUserData NOTIFY userDataChanged)
 
 public:
+    enum Type
+    {
+        Basic = 0,
+        Channel,
+        Custom
+    };
+    Q_ENUM(Type)
+
     Q_INVOKABLE explicit IrcBuffer(QObject* parent = nullptr);
     ~IrcBuffer() override;
 

--- a/include/IrcModel/ircbuffer_p.h
+++ b/include/IrcModel/ircbuffer_p.h
@@ -91,6 +91,7 @@ public:
     QVariantMap userData;
     QDateTime activity;
     MonitorStatus monitorStatus = MonitorUnknown;
+    IrcBuffer::Type type = IrcBuffer::Basic;
 };
 
 IRC_END_NAMESPACE

--- a/src/model/ircbuffer.cpp
+++ b/src/model/ircbuffer.cpp
@@ -392,7 +392,8 @@ void IrcBuffer::setPrefix(const QString& prefix)
  */
 bool IrcBuffer::isChannel() const
 {
-    return qobject_cast<const IrcChannel*>(this);
+    Q_D(const IrcBuffer);
+    return (d->type == IrcBuffer::Channel);
 }
 
 /*!

--- a/src/model/ircchannel.cpp
+++ b/src/model/ircchannel.cpp
@@ -497,6 +497,8 @@ bool IrcChannelPrivate::processWhoReplyMessage(IrcWhoReplyMessage *message)
 IrcChannel::IrcChannel(QObject* parent)
     : IrcBuffer(*new IrcChannelPrivate, parent)
 {
+    Q_D(IrcChannel);
+    d->type = IrcBuffer::Channel;
 }
 
 /*!


### PR DESCRIPTION
At the moment that buffer model checks for the isChannel(qobject_cast)
it does not work anymore because the channel class destructor was already
called.

Instead of qobject_cast use now an enum buffer type flag, that will keep
valid until the base buffer object gets destroyed.