### PR TITLE
Add a way to send messages to the server before authenticating

### DIFF
--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -55,6 +55,7 @@ class IRC_CORE_EXPORT IrcConnection : public QObject
     Q_PROPERTY(QString userName READ userName WRITE setUserName NOTIFY userNameChanged)
     Q_PROPERTY(QString nickName READ nickName WRITE setNickName NOTIFY nickNameChanged)
     Q_PROPERTY(QString realName READ realName WRITE setRealName NOTIFY realNameChanged)
+    Q_PROPERTY(QByteArray preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
     Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
     Q_PROPERTY(QStringList nickNames READ nickNames WRITE setNickNames NOTIFY nickNamesChanged)
     Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged)
@@ -102,6 +103,9 @@ public:
 
     QString realName() const;
     void setRealName(const QString& name);
+
+    QByteArray preAuthMessage() const;
+    void setPreAuthMessage(const QByteArray& preAuthMessage);
 
     QString password() const;
     void setPassword(const QString& password);
@@ -223,6 +227,7 @@ Q_SIGNALS:
     void userNameChanged(const QString& name);
     void nickNameChanged(const QString& name);
     void realNameChanged(const QString& name);
+    void preAuthMessageChanged(const QByteArray& preAuthMessage);
     void passwordChanged(const QString& password);
     void nickNamesChanged(const QStringList& names);
     void displayNameChanged(const QString& name);

--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -55,7 +55,7 @@ class IRC_CORE_EXPORT IrcConnection : public QObject
     Q_PROPERTY(QString userName READ userName WRITE setUserName NOTIFY userNameChanged)
     Q_PROPERTY(QString nickName READ nickName WRITE setNickName NOTIFY nickNameChanged)
     Q_PROPERTY(QString realName READ realName WRITE setRealName NOTIFY realNameChanged)
-    Q_PROPERTY(QString preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
+    Q_PROPERTY(QStringList authMessages READ authMessages WRITE setAuthMessages NOTIFY authMessagesChanged)
     Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
     Q_PROPERTY(QStringList nickNames READ nickNames WRITE setNickNames NOTIFY nickNamesChanged)
     Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged)
@@ -104,8 +104,8 @@ public:
     QString realName() const;
     void setRealName(const QString& name);
 
-    QString preAuthMessage() const;
-    void setPreAuthMessage(const QString& preAuthMessage);
+    QStringList authMessages() const;
+    void setAuthMessages(const QStringList& authMessages);
 
     QString password() const;
     void setPassword(const QString& password);
@@ -227,7 +227,7 @@ Q_SIGNALS:
     void userNameChanged(const QString& name);
     void nickNameChanged(const QString& name);
     void realNameChanged(const QString& name);
-    void preAuthMessageChanged(const QString& preAuthMessage);
+    void authMessagesChanged(const QStringList& authMessages);
     void passwordChanged(const QString& password);
     void nickNamesChanged(const QStringList& names);
     void displayNameChanged(const QString& name);

--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -55,7 +55,7 @@ class IRC_CORE_EXPORT IrcConnection : public QObject
     Q_PROPERTY(QString userName READ userName WRITE setUserName NOTIFY userNameChanged)
     Q_PROPERTY(QString nickName READ nickName WRITE setNickName NOTIFY nickNameChanged)
     Q_PROPERTY(QString realName READ realName WRITE setRealName NOTIFY realNameChanged)
-    Q_PROPERTY(QByteArray preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
+    Q_PROPERTY(QString preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
     Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
     Q_PROPERTY(QStringList nickNames READ nickNames WRITE setNickNames NOTIFY nickNamesChanged)
     Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged)
@@ -104,8 +104,8 @@ public:
     QString realName() const;
     void setRealName(const QString& name);
 
-    QByteArray preAuthMessage() const;
-    void setPreAuthMessage(const QByteArray& preAuthMessage);
+    QString preAuthMessage() const;
+    void setPreAuthMessage(const QString& preAuthMessage);
 
     QString password() const;
     void setPassword(const QString& password);
@@ -227,7 +227,7 @@ Q_SIGNALS:
     void userNameChanged(const QString& name);
     void nickNameChanged(const QString& name);
     void realNameChanged(const QString& name);
-    void preAuthMessageChanged(const QByteArray& preAuthMessage);
+    void preAuthMessageChanged(const QString& preAuthMessage);
     void passwordChanged(const QString& password);
     void nickNamesChanged(const QStringList& names);
     void displayNameChanged(const QString& name);

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,7 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
-    QByteArray preAuthMessage = "";
+    QByteArray preAuthMessage;
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,6 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
+    QByteArray preAuthMessage = "";
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,7 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
-    QByteArray preAuthMessage;
+    QString preAuthMessage;
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,7 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
-    QString preAuthMessage;
+    QStringList authMessages;
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -872,28 +872,28 @@ void IrcConnection::setRealName(const QString& name)
 }
 
 /*!
-    This property holds a message which will be sent to server before password while authenticating.
+    This property holds messages which will be sent to server before password while authenticating.
 
     \par Access functions:
-    \li QString <b>preAuthMessage</b>() const
-    \li void <b>setPreAuthMessage</b>(const QString& preAuthMessage)
+    \li QStringList <b>authMessages</b>() const
+    \li void <b>setAuthMessages</b>(const QStringList& authMessages)
 
     \par Notifier signal:
-    \li void <b>preAuthMessageChanged</b>(const QString& preAuthMessage)
+    \li void <b>authMessagesChanged</b>(const QStringList& authMessages)
  */
 
-QString IrcConnection::preAuthMessage() const
+QStringList IrcConnection::authMessages() const
 {
     Q_D(const IrcConnection);
-    return d->preAuthMessage;
+    return d->authMessages;
 }
 
-void IrcConnection::setPreAuthMessage(const QString& preAuthMessage)
+void IrcConnection::setAuthMessages(const QStringList& authMessages)
 {
     Q_D(IrcConnection);
-    if (d->preAuthMessage != preAuthMessage){
-        d->preAuthMessage = preAuthMessage;
-        emit preAuthMessageChanged(preAuthMessage);
+    if (d->authMessages != authMessages){
+        d->authMessages = authMessages;
+        emit authMessagesChanged(authMessages);
     }
 }
 

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -872,6 +872,25 @@ void IrcConnection::setRealName(const QString& name)
 }
 
 /*!
+  This property holds message which will be sent to server before passing password while authenticating.
+ */
+
+QByteArray IrcConnection::preAuthMessage() const
+{
+    Q_D(const IrcConnection);
+    return d->preAuthMessage;
+}
+
+void IrcConnection::setPreAuthMessage(const QByteArray &preAuthMessage)
+{
+    Q_D(IrcConnection);
+    if (d->preAuthMessage != preAuthMessage){
+        d->preAuthMessage = preAuthMessage;
+        emit preAuthMessageChanged(preAuthMessage);
+    }
+}
+
+/*!
     This property holds the password.
 
     \par Access functions:

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -875,7 +875,7 @@ void IrcConnection::setRealName(const QString& name)
   This property holds message which will be sent to server before passing password while authenticating.
  */
 
-QByteArray IrcConnection::preAuthMessage() const
+QString IrcConnection::preAuthMessage() const
 {
     Q_D(const IrcConnection);
     return d->preAuthMessage;

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -881,7 +881,7 @@ QByteArray IrcConnection::preAuthMessage() const
     return d->preAuthMessage;
 }
 
-void IrcConnection::setPreAuthMessage(const QByteArray &preAuthMessage)
+void IrcConnection::setPreAuthMessage(const QString& preAuthMessage)
 {
     Q_D(IrcConnection);
     if (d->preAuthMessage != preAuthMessage){

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -872,7 +872,14 @@ void IrcConnection::setRealName(const QString& name)
 }
 
 /*!
-  This property holds message which will be sent to server before passing password while authenticating.
+    This property holds a message which will be sent to server before password while authenticating.
+
+    \par Access functions:
+    \li QString <b>preAuthMessage</b>() const
+    \li void <b>setPreAuthMessage</b>(const QString& preAuthMessage)
+
+    \par Notifier signal:
+    \li void <b>preAuthMessageChanged</b>(const QString& preAuthMessage)
  */
 
 QString IrcConnection::preAuthMessage() const

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -103,7 +103,7 @@ void IrcProtocolPrivate::authenticate(bool secure)
             const QByteArray data = userName + '\0' + userName + '\0' + password.toUtf8();
             authed = connection->sendData("AUTHENTICATE " + data.toBase64());
         } else {
-            if (!preAuthMessage.isEmpty()){
+            if (!preAuthMessage.isEmpty()) {
                 connection->sendRaw(preAuthMessage);
             }
             authed = connection->sendRaw(QString("PASS :%1").arg(password));

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -97,15 +97,15 @@ void IrcProtocolPrivate::authenticate(bool secure)
 {
     const QString password = connection->password();
     const QString preAuthMessage = connection->preAuthMessage();
+    if (!preAuthMessage.isEmpty()) {
+        connection->sendRaw(preAuthMessage);
+    }
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();
             const QByteArray data = userName + '\0' + userName + '\0' + password.toUtf8();
             authed = connection->sendData("AUTHENTICATE " + data.toBase64());
         } else {
-            if (!preAuthMessage.isEmpty()) {
-                connection->sendRaw(preAuthMessage);
-            }
             authed = connection->sendRaw(QString("PASS :%1").arg(password));
         }
     }

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -95,11 +95,11 @@ IrcProtocolPrivate::IrcProtocolPrivate()
 
 void IrcProtocolPrivate::authenticate(bool secure)
 {
-    const QString password = connection->password();
-    const QString preAuthMessage = connection->preAuthMessage();
-    if (!preAuthMessage.isEmpty()) {
-        connection->sendRaw(preAuthMessage);
+    for (const QString& message : connection->authMessages()){
+        connection->sendRaw(message);
     }
+
+    const QString password = connection->password();
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -96,7 +96,7 @@ IrcProtocolPrivate::IrcProtocolPrivate()
 void IrcProtocolPrivate::authenticate(bool secure)
 {
     const QString password = connection->password();
-    const QByteArray preAuthMessage = connection->preAuthMessage();
+    const QString preAuthMessage = connection->preAuthMessage();
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -96,12 +96,16 @@ IrcProtocolPrivate::IrcProtocolPrivate()
 void IrcProtocolPrivate::authenticate(bool secure)
 {
     const QString password = connection->password();
+    const QByteArray preAuthMessage = connection->preAuthMessage();
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();
             const QByteArray data = userName + '\0' + userName + '\0' + password.toUtf8();
             authed = connection->sendData("AUTHENTICATE " + data.toBase64());
         } else {
+            if (!preAuthMessage.isEmpty()){
+                connection->sendRaw(preAuthMessage);
+            }
             authed = connection->sendRaw(QString("PASS :%1").arg(password));
         }
     }

--- a/tests/auto/ircconnection/tst_ircconnection.cpp
+++ b/tests/auto/ircconnection/tst_ircconnection.cpp
@@ -67,6 +67,9 @@ private slots:
     void testRealName_data();
     void testRealName();
 
+    void testAuthMessage_data();
+    void testAuthMessage();
+
     void testPassword_data();
     void testPassword();
 
@@ -122,6 +125,7 @@ void tst_IrcConnection::testDefaults()
     QVERIFY(connection.userName().isNull());
     QVERIFY(connection.nickName().isNull());
     QVERIFY(connection.realName().isNull());
+    QVERIFY(connection.authMessages().isEmpty());
     QVERIFY(connection.password().isNull());
     QVERIFY(connection.displayName().isNull());
     QCOMPARE(connection.encoding(), QByteArray("ISO-8859-15"));
@@ -266,6 +270,42 @@ void tst_IrcConnection::testRealName()
     QCOMPARE(spy.count(), !result.isEmpty() ? 1 : 0);
     if (!spy.isEmpty())
         QCOMPARE(spy.first().first().toString(), result);
+}
+
+void tst_IrcConnection::testAuthMessage_data()
+{
+    QTest::addColumn<QStringList>("authmsgs");
+    QTest::addColumn<QStringList>("result");
+
+    QTest::newRow("null") << QStringList() << QStringList();
+    QTest::newRow("empty") << QStringList({}) << QStringList();
+    QTest::newRow("emptystr") << QStringList({QString()}) << QStringList({""});
+    QTest::newRow("qstring") << QStringList({QString("foo")}) << QStringList({"foo"});
+    QTest::newRow("qbytearray") << QStringList({QByteArray("foo")}) << QStringList({"foo"});
+    QTest::newRow("multiple") << QStringList({"foo", "bar", "baz"}) << QStringList({"foo", "bar", "baz"});
+}
+
+void tst_IrcConnection::testAuthMessage()
+{
+    QFETCH(QStringList, authmsgs);
+    QFETCH(QStringList, result);
+
+    IrcConnection connection;
+    QSignalSpy spy(&connection, SIGNAL(authMessagesChanged(QStringList)));
+    QVERIFY(spy.isValid());
+    connection.setAuthMessages(authmsgs);
+    QCOMPARE(connection.authMessages(), result);
+    QCOMPARE(spy.size(), result.isEmpty() ? 0 : 1);
+
+    if (result.isEmpty())
+        return;
+
+    auto spyList = spy.first().first().toStringList();
+    QCOMPARE(spyList.size(), result.size());
+    for (int i = 0; i < spyList.size(); i++)
+    {
+        QCOMPARE(spyList.at(i), result.at(i));
+    }
 }
 
 void tst_IrcConnection::testPassword_data()


### PR DESCRIPTION
This Pull Request adds a new property to connection class - `authMessages`, which will contain messages that can be specified and sent to the server before sending PASS and NICK.
This is very necessary in my case - after successfully authenticating to Twitch IRC servers it can send us a `GLOBALUSERSTATE` message, but only if a special message before authenticating has been sent. Without this feature I was not able to receive the mentioned message in any way.

I hope my documentation, tests and comments are clear. I'll be happy to clarify everything and I hope I can get this merged into master,