### PR TITLE
Add a way to skip capability validation

### DIFF
--- a/include/IrcCore/ircnetwork.h
+++ b/include/IrcCore/ircnetwork.h
@@ -52,6 +52,7 @@ class IRC_CORE_EXPORT IrcNetwork : public QObject
     Q_PROPERTY(QStringList availableCapabilities READ availableCapabilities NOTIFY availableCapabilitiesChanged)
     Q_PROPERTY(QStringList requestedCapabilities READ requestedCapabilities WRITE setRequestedCapabilities NOTIFY requestedCapabilitiesChanged)
     Q_PROPERTY(QStringList activeCapabilities READ activeCapabilities NOTIFY activeCapabilitiesChanged)
+    Q_PROPERTY(bool skipCapabilityValidation READ skipCapabilityValidation WRITE setSkipCapabilityValidation NOTIFY skipCapabilityValidationChanged)
     Q_ENUMS(Limit ModeType)
     Q_FLAGS(ModeTypes)
 
@@ -104,6 +105,7 @@ public:
     QStringList availableCapabilities() const;
     QStringList requestedCapabilities() const;
     QStringList activeCapabilities() const;
+    bool skipCapabilityValidation() const;
 
     Q_INVOKABLE bool hasCapability(const QString& capability) const;
     Q_INVOKABLE bool isCapable(const QString& capability) const;
@@ -112,6 +114,7 @@ public Q_SLOTS:
     bool requestCapability(const QString& capability);
     bool requestCapabilities(const QStringList& capabilities);
     void setRequestedCapabilities(const QStringList& capabilities);
+    void setSkipCapabilityValidation(bool skip);
 
 Q_SIGNALS:
     void initialized();
@@ -123,6 +126,7 @@ Q_SIGNALS:
     void availableCapabilitiesChanged(const QStringList& capabilities);
     void requestedCapabilitiesChanged(const QStringList& capabilities);
     void activeCapabilitiesChanged(const QStringList& capabilities);
+    void skipCapabilityValidationChanged(bool skip);
     void requestingCapabilities();
 
 private:

--- a/include/IrcCore/ircnetwork_p.h
+++ b/include/IrcCore/ircnetwork_p.h
@@ -75,6 +75,7 @@ public:
     QStringList modes, prefixes, channelTypes, channelModes, statusPrefixes;
     QHash<QString, int> numericLimits, modeLimits, channelLimits, targetLimits;
     QSet<QString> availableCaps, requestedCaps, activeCaps;
+    bool skipCapabilityValidation = false;
 };
 
 IRC_END_NAMESPACE

--- a/src/core/ircnetwork.cpp
+++ b/src/core/ircnetwork.cpp
@@ -681,6 +681,37 @@ QStringList IrcNetwork::requestedCapabilities() const
     return IrcPrivate::setToList(d->requestedCaps);
 }
 
+
+/*!
+    This property specifies whether we should request capabilities right away
+    after establishing connecting or not. Otherwise, we wait for CAP * LS and
+    check if capabilities we're about to request are supported by the server.
+
+    By default this is set to false
+
+    \par Access functions:
+    \li bool <b>skipCapabilityValidation</b>() const
+    \li void <b>setSkipCapabilityValidation</b>(bool skip)
+
+    \par Notifier signal:
+    \li void <b>skipCapabilityValidationChanged</b>(bool skip)
+ */
+
+bool IrcNetwork::skipCapabilityValidation() const
+{
+    Q_D(const IrcNetwork);
+    return d->skipCapabilityValidation;
+}
+
+void IrcNetwork::setSkipCapabilityValidation(bool skip)
+{
+    Q_D(IrcNetwork);
+    if (d->skipCapabilityValidation != skip) {
+        d->skipCapabilityValidation = skip;
+        emit skipCapabilityValidationChanged(skip);
+    }
+}
+
 void IrcNetwork::setRequestedCapabilities(const QStringList& capabilities)
 {
     Q_D(IrcNetwork);

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -371,10 +371,14 @@ void IrcProtocolPrivate::handleCapabilityMessage(IrcCapabilityMessage* msg)
 
 void IrcProtocolPrivate::_irc_pauseHandshake()
 {
-    // Send CAP LS first; if the server understands it this will
-    // temporarily pause the handshake until CAP END is sent, so we
-    // know whether the server supports the CAP extension.
-    connection->sendData("CAP LS 302");
+    if (connection->network()->skipCapabilityValidation()) {
+        connection->sendRaw("CAP REQ :" + connection->network()->requestedCapabilities().join(" "));
+    } else {
+        // Send CAP LS first; if the server understands it this will
+        // temporarily pause the handshake until CAP END is sent, so we
+        // know whether the server supports the CAP extension.
+        connection->sendData("CAP LS 302");
+    }
     resumed = false;
     authed = false;
 }


### PR DESCRIPTION
As suggested in https://github.com/communi/libcommuni/pull/98#issuecomment-872923942

> Maybe just a flag if the caps should be validated or not and if not, send the request right away.
