### PR TITLE
Replace deprecated QRegExp with QRegularExpression

### DIFF
--- a/include/IrcCore/ircdebug_p.h
+++ b/include/IrcCore/ircdebug_p.h
@@ -33,8 +33,8 @@
 #include <IrcConnection>
 #include <QtCore/qdebug.h>
 #include <QtCore/qstring.h>
-#include <QtCore/qregexp.h>
 #include <QtCore/qdatetime.h>
+#include <QRegularExpression>
 
 IRC_BEGIN_NAMESPACE
 
@@ -143,7 +143,7 @@ static bool irc_debug_enabled(IrcConnection* c, uint l)
         dbg_init = true;
     }
 
-    return l <= dbg_level && (dbg_name.isEmpty() || QRegExp(dbg_name, Qt::CaseInsensitive, QRegExp::Wildcard).exactMatch(c->displayName()));
+    return l <= dbg_level && (dbg_name.isEmpty() || QRegularExpression(QRegularExpression::wildcardToRegularExpression(dbg_name), QRegularExpression::CaseInsensitiveOption).match(c->displayName()).hasMatch());
 }
 
 #define ircDebug(Connection, Flag) IrcDebug(Connection, Flag)

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -39,7 +39,7 @@
 #include "irccore_p.h"
 #include "irc.h"
 #include <QLocale>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QDateTime>
 #include <QTcpSocket>
 #include <QTextCodec>
@@ -365,7 +365,7 @@ void IrcConnectionPrivate::_irc_filterDestroyed(QObject* filter)
 
 static bool parseServer(const QString& server, QString* host, int* port, bool* ssl)
 {
-    QStringList p = server.split(QRegExp("[: ]"), Qt::SkipEmptyParts);
+    QStringList p = server.split(QRegularExpression("[: ]"), Qt::SkipEmptyParts);
     *host = p.value(0);
     *ssl = p.value(1).startsWith(QLatin1Char('+'));
     bool ok = false;

--- a/src/util/irccommandparser.cpp
+++ b/src/util/irccommandparser.cpp
@@ -31,6 +31,7 @@
 #include "irctoken_p.h"
 #include "irccore_p.h"
 #include <climits>
+#include <QRegularExpression>
 
 IRC_BEGIN_NAMESPACE
 
@@ -374,7 +375,7 @@ QString IrcCommandParser::syntax(const QString& command, Details details) const
         QString str = info.fullSyntax();
         if (details != Full) {
             if (details & NoTarget)
-                str.remove(QRegExp("\\[[^\\]]+\\]"));
+                str.remove(QRegularExpression("\\[[^\\]]+\\]"));
             if (details & NoPrefix)
                 str.remove("#");
             if (details & NoEllipsis)

--- a/src/util/irctextformat.cpp
+++ b/src/util/irctextformat.cpp
@@ -111,24 +111,11 @@ static bool parseColors(const QString& message, int pos, int* len, int* fg = nul
         *fg = -1;
     if (bg)
         *bg = -1;
-//    QRegExp rx(QLatin1String("(\\d{1,2})(?:,(\\d{1,2}))?"));
-//    int idx = rx.indexIn(message, pos);
-//    if (idx == pos) {
-//        *len = rx.matchedLength();
-//        if (fg)
-//            *fg = rx.cap(1).toInt();
-//        if (bg) {
-//            bool ok = false;
-//            int tmp = rx.cap(2).toInt(&ok);
-//            if (ok)
-//                *bg = tmp;
-//        }
-//    }
-    QRegularExpression re(QLatin1String("(\\d{1,2})(?:,(\\d{1,2}))?"));
+
+    QRegularExpression re("(\\d{1,2})(?:,(\\d{1,2}))?");
     auto match = re.match(message, pos);
-    qDebug() << match.lastCapturedIndex() << pos << match.hasMatch() << message;
-    if (match.lastCapturedIndex() == pos) {
-        *len = match.capturedTexts().size() - 1;
+    if (match.hasMatch()) {
+        *len = match.captured().length();
         if (fg)
             *fg = match.captured(1).toInt();
         if (bg) {

--- a/tests/auto/irc/tst_irc.cpp
+++ b/tests/auto/irc/tst_irc.cpp
@@ -12,7 +12,6 @@
 #include "ircmodel.h"
 #include "ircutil.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 
 class tst_Irc : public QObject
 {

--- a/tests/auto/ircbuffer/tst_ircbuffer.cpp
+++ b/tests/auto/ircbuffer/tst_ircbuffer.cpp
@@ -14,7 +14,6 @@
 #include "ircmessage.h"
 #include "ircfilter.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 
 class tst_IrcBuffer : public QObject
 {
@@ -148,17 +147,17 @@ void tst_IrcBuffer::testDebug()
 
     IrcBuffer buffer;
     dbg << &buffer;
-    QVERIFY(QRegExp("IrcBuffer\\(0x[0-9A-Fa-f]+\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcBuffer\\(0x[0-9A-Fa-f]+\\) ").match(str).hasMatch());
     str.clear();
 
     buffer.setObjectName("obj");
     dbg << &buffer;
-    QVERIFY(QRegExp("IrcBuffer\\(0x[0-9A-Fa-f]+, name=obj\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcBuffer\\(0x[0-9A-Fa-f]+, name=obj\\) ").match(str).hasMatch());
     str.clear();
 
     buffer.setName("buf");
     dbg << &buffer;
-    QVERIFY(QRegExp("IrcBuffer\\(0x[0-9A-Fa-f]+, name=obj, title=buf\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcBuffer\\(0x[0-9A-Fa-f]+, name=obj, title=buf\\) ").match(str).hasMatch());
     str.clear();
 }
 

--- a/tests/auto/ircchannel/tst_ircchannel.cpp
+++ b/tests/auto/ircchannel/tst_ircchannel.cpp
@@ -9,7 +9,6 @@
 
 #include "ircchannel.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 
 class tst_IrcChannel : public QObject
 {
@@ -59,18 +58,18 @@ void tst_IrcChannel::testDebug()
 
     IrcChannel channel;
     dbg << &channel;
-    QVERIFY(QRegExp("IrcChannel\\(0x[0-9A-Fa-f]+\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcChannel\\(0x[0-9A-Fa-f]+\\) ").match(str).hasMatch());
     str.clear();
 
     channel.setObjectName("obj");
     dbg << &channel;
-    QVERIFY(QRegExp("IrcChannel\\(0x[0-9A-Fa-f]+, name=obj\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcChannel\\(0x[0-9A-Fa-f]+, name=obj\\) ").match(str).hasMatch());
     str.clear();
 
     channel.setPrefix("#");
     channel.setName("communi");
     dbg << &channel;
-    QVERIFY(QRegExp("IrcChannel\\(0x[0-9A-Fa-f]+, name=obj, title=#communi\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcChannel\\(0x[0-9A-Fa-f]+, name=obj, title=#communi\\) ").match(str).hasMatch());
     str.clear();
 }
 

--- a/tests/auto/irccommand/tst_irccommand.cpp
+++ b/tests/auto/irccommand/tst_irccommand.cpp
@@ -11,7 +11,6 @@
 #include "ircmessage.h"
 #include "ircconnection.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 #include <QtCore/QTextCodec>
 #include <QtCore/QScopedPointer>
 
@@ -147,8 +146,8 @@ void tst_IrcCommand::testAdmin()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Admin);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bADMIN\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bADMIN\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testAway()
@@ -157,8 +156,8 @@ void tst_IrcCommand::testAway()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Away);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bAWAY\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\breason\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bAWAY\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\breason\\b")));
 }
 
 void tst_IrcCommand::testCapability()
@@ -167,18 +166,18 @@ void tst_IrcCommand::testCapability()
     QVERIFY(cmd1.data());
 
     QCOMPARE(cmd1->type(), IrcCommand::Capability);
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bCAP\\b")));
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bsub\\b")));
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bcap\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bCAP\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bsub\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bcap\\b")));
 
     QScopedPointer<IrcCommand> cmd2(IrcCommand::createCapability("sub", QStringList() << "cap1" << "cap2"));
     QVERIFY(cmd2.data());
 
     QCOMPARE(cmd2->type(), IrcCommand::Capability);
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bCAP\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bsub\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bcap1\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bcap2\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bCAP\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bsub\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bcap1\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bcap2\\b")));
 }
 
 void tst_IrcCommand::testCtcpAction()
@@ -187,9 +186,9 @@ void tst_IrcCommand::testCtcpAction()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::CtcpAction);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bPRIVMSG\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btgt\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bact\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bPRIVMSG\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btgt\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bact\\b")));
     QCOMPARE(cmd->toString().count("\01"), 2);
 }
 
@@ -199,9 +198,9 @@ void tst_IrcCommand::testCtcpReply()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::CtcpReply);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bNOTICE\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btgt\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\brpl\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bNOTICE\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btgt\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\brpl\\b")));
     QCOMPARE(cmd->toString().count("\01"), 2);
 }
 
@@ -211,9 +210,9 @@ void tst_IrcCommand::testCtcpRequest()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::CtcpRequest);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bPRIVMSG\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btgt\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\breq\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bPRIVMSG\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btgt\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\breq\\b")));
     QCOMPARE(cmd->toString().count("\01"), 2);
 }
 
@@ -223,8 +222,8 @@ void tst_IrcCommand::testInfo()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Info);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bINFO\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bINFO\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testInvite()
@@ -233,9 +232,9 @@ void tst_IrcCommand::testInvite()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Invite);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bINVITE\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\busr\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bchan\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bINVITE\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\busr\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bchan\\b")));
 }
 
 void tst_IrcCommand::testJoin()
@@ -244,24 +243,24 @@ void tst_IrcCommand::testJoin()
     QVERIFY(cmd1.data());
 
     QCOMPARE(cmd1->type(), IrcCommand::Join);
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bJOIN\\b")));
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bchan\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bJOIN\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bchan\\b")));
 
     QScopedPointer<IrcCommand> cmd2(IrcCommand::createJoin(QStringList() << "chan1" << "chan2"));
     QVERIFY(cmd2.data());
 
     QCOMPARE(cmd2->type(), IrcCommand::Join);
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bJOIN\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bchan1\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bchan2\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bJOIN\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bchan1\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bchan2\\b")));
 
     QScopedPointer<IrcCommand> cmd3(IrcCommand::createJoin(QStringList() << "chan1" << "chan2", QStringList() << "key1" << "key2"));
     QVERIFY(cmd3.data());
 
     QCOMPARE(cmd3->type(), IrcCommand::Join);
-    QVERIFY(cmd3->toString().contains(QRegExp("\\bJOIN\\b")));
-    QVERIFY(cmd3->toString().contains(QRegExp("\\bchan1,chan2\\b")));
-    QVERIFY(cmd3->toString().contains(QRegExp("\\bkey1,key2\\b")));
+    QVERIFY(cmd3->toString().contains(QRegularExpression("\\bJOIN\\b")));
+    QVERIFY(cmd3->toString().contains(QRegularExpression("\\bchan1,chan2\\b")));
+    QVERIFY(cmd3->toString().contains(QRegularExpression("\\bkey1,key2\\b")));
 }
 
 void tst_IrcCommand::testKick()
@@ -270,9 +269,9 @@ void tst_IrcCommand::testKick()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Kick);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bKICK\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bchan\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\busr\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bKICK\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bchan\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\busr\\b")));
 }
 
 void tst_IrcCommand::testKnock()
@@ -281,8 +280,8 @@ void tst_IrcCommand::testKnock()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Knock);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bKNOCK\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bchan\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bKNOCK\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bchan\\b")));
 }
 
 void tst_IrcCommand::testList()
@@ -291,10 +290,10 @@ void tst_IrcCommand::testList()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::List);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bLIST\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bchan1\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bchan2\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bLIST\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bchan1\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bchan2\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testMessage()
@@ -303,9 +302,9 @@ void tst_IrcCommand::testMessage()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Message);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bPRIVMSG\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btgt\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bmsg\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bPRIVMSG\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btgt\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bmsg\\b")));
 }
 
 void tst_IrcCommand::testMode()
@@ -314,9 +313,9 @@ void tst_IrcCommand::testMode()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Mode);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bMODE\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btgt\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bmode\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bMODE\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btgt\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bmode\\b")));
 }
 
 void tst_IrcCommand::testMonitor()
@@ -325,16 +324,16 @@ void tst_IrcCommand::testMonitor()
     QVERIFY(cmd1.data());
 
     QCOMPARE(cmd1->type(), IrcCommand::Monitor);
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bMONITOR\\b")));
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bfoo\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bMONITOR\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bfoo\\b")));
 
     QScopedPointer<IrcCommand> cmd2(IrcCommand::createMonitor("+", QStringList() << "foo" << "bar"));
     QVERIFY(cmd2.data());
 
     QCOMPARE(cmd2->type(), IrcCommand::Monitor);
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bMONITOR\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bfoo\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bbar\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bMONITOR\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bfoo\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bbar\\b")));
 }
 
 void tst_IrcCommand::testMotd()
@@ -343,8 +342,8 @@ void tst_IrcCommand::testMotd()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Motd);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bMOTD\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bMOTD\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testNames()
@@ -353,16 +352,16 @@ void tst_IrcCommand::testNames()
     QVERIFY(cmd1.data());
 
     QCOMPARE(cmd1->type(), IrcCommand::Names);
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bNAMES\\b")));
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bchan\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bNAMES\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bchan\\b")));
 
     QScopedPointer<IrcCommand> cmd2(IrcCommand::createNames(QStringList() << "chan1" << "chan2"));
     QVERIFY(cmd2.data());
 
     QCOMPARE(cmd2->type(), IrcCommand::Names);
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bNAMES\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bchan1\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bchan2\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bNAMES\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bchan1\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bchan2\\b")));
 }
 
 void tst_IrcCommand::testNick()
@@ -371,8 +370,8 @@ void tst_IrcCommand::testNick()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Nick);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bNICK\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bnick\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bNICK\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bnick\\b")));
 }
 
 void tst_IrcCommand::testNotice()
@@ -381,9 +380,9 @@ void tst_IrcCommand::testNotice()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Notice);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bNOTICE\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btgt\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bmsg\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bNOTICE\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btgt\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bmsg\\b")));
 }
 
 void tst_IrcCommand::testPart()
@@ -392,16 +391,16 @@ void tst_IrcCommand::testPart()
     QVERIFY(cmd1.data());
 
     QCOMPARE(cmd1->type(), IrcCommand::Part);
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bPART\\b")));
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bchan\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bPART\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bchan\\b")));
 
     QScopedPointer<IrcCommand> cmd2(IrcCommand::createPart(QStringList() << "chan1" << "chan2"));
     QVERIFY(cmd2.data());
 
     QCOMPARE(cmd2->type(), IrcCommand::Part);
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bPART\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bchan1\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bchan2\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bPART\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bchan1\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bchan2\\b")));
 }
 
 void tst_IrcCommand::testPing()
@@ -410,8 +409,8 @@ void tst_IrcCommand::testPing()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Ping);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bPING\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\barg\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bPING\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\barg\\b")));
 }
 
 void tst_IrcCommand::testPong()
@@ -420,8 +419,8 @@ void tst_IrcCommand::testPong()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Pong);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bPONG\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\barg\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bPONG\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\barg\\b")));
 }
 
 void tst_IrcCommand::testQuit()
@@ -430,8 +429,8 @@ void tst_IrcCommand::testQuit()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Quit);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bQUIT\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\breason\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bQUIT\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\breason\\b")));
 }
 
 void tst_IrcCommand::testQuote()
@@ -440,14 +439,14 @@ void tst_IrcCommand::testQuote()
     QVERIFY(cmd1.data());
 
     QCOMPARE(cmd1->type(), IrcCommand::Quote);
-    QVERIFY(cmd1->toString().contains(QRegExp("\\bCUSTOM\\b")));
+    QVERIFY(cmd1->toString().contains(QRegularExpression("\\bCUSTOM\\b")));
 
     QScopedPointer<IrcCommand> cmd2(IrcCommand::createQuote(QStringList() << "FOO" << "BAR"));
     QVERIFY(cmd2.data());
 
     QCOMPARE(cmd2->type(), IrcCommand::Quote);
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bFOO\\b")));
-    QVERIFY(cmd2->toString().contains(QRegExp("\\bBAR\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bFOO\\b")));
+    QVERIFY(cmd2->toString().contains(QRegularExpression("\\bBAR\\b")));
 }
 
 void tst_IrcCommand::testStats()
@@ -456,9 +455,9 @@ void tst_IrcCommand::testStats()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Stats);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bSTATS\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bquery\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bSTATS\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bquery\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testTime()
@@ -467,8 +466,8 @@ void tst_IrcCommand::testTime()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Time);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bTIME\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bTIME\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testTopic()
@@ -477,9 +476,9 @@ void tst_IrcCommand::testTopic()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Topic);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bTOPIC\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bchan\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btopic\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bTOPIC\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bchan\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btopic\\b")));
 }
 
 void tst_IrcCommand::testTrace()
@@ -488,8 +487,8 @@ void tst_IrcCommand::testTrace()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Trace);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bTRACE\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\btarget\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bTRACE\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\btarget\\b")));
 }
 
 void tst_IrcCommand::testUsers()
@@ -498,8 +497,8 @@ void tst_IrcCommand::testUsers()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Users);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bUSERS\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bserver\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bUSERS\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bserver\\b")));
 }
 
 void tst_IrcCommand::testVersion()
@@ -508,8 +507,8 @@ void tst_IrcCommand::testVersion()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Version);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bVERSION\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\buser\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bVERSION\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\buser\\b")));
 }
 
 void tst_IrcCommand::testWho()
@@ -518,8 +517,8 @@ void tst_IrcCommand::testWho()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Who);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bWHO\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bmask\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bWHO\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bmask\\b")));
 }
 
 void tst_IrcCommand::testWhois()
@@ -528,8 +527,8 @@ void tst_IrcCommand::testWhois()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Whois);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bWHOIS\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bmask\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bWHOIS\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bmask\\b")));
 }
 
 void tst_IrcCommand::testWhowas()
@@ -538,8 +537,8 @@ void tst_IrcCommand::testWhowas()
     QVERIFY(cmd.data());
 
     QCOMPARE(cmd->type(), IrcCommand::Whowas);
-    QVERIFY(cmd->toString().contains(QRegExp("\\bWHOWAS\\b")));
-    QVERIFY(cmd->toString().contains(QRegExp("\\bmask\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bWHOWAS\\b")));
+    QVERIFY(cmd->toString().contains(QRegularExpression("\\bmask\\b")));
 }
 
 void tst_IrcCommand::testDebug()
@@ -554,17 +553,17 @@ void tst_IrcCommand::testDebug()
     IrcCommand command;
     QTest::ignoreMessage(QtWarningMsg, "Reimplement IrcCommand::toString() for IrcCommand::Custom");
     dbg << &command;
-    QVERIFY(QRegExp("IrcCommand\\(0x[0-9A-Fa-f]+, type=Custom\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcCommand\\(0x[0-9A-Fa-f]+, type=Custom\\) ").match(str).hasMatch());
     str.clear();
 
     command.setType(IrcCommand::Quit);
     dbg << &command;
-    QVERIFY(QRegExp("IrcCommand\\(0x[0-9A-Fa-f]+, type=Quit, \"QUIT :\"\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcCommand\\(0x[0-9A-Fa-f]+, type=Quit, \"QUIT :\"\\) ").match(str).hasMatch());
     str.clear();
 
     command.setObjectName("foo");
     dbg << &command;
-    QVERIFY(QRegExp("IrcCommand\\(0x[0-9A-Fa-f]+, name=foo, type=Quit, \"QUIT :\"\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcCommand\\(0x[0-9A-Fa-f]+, name=foo, type=Quit, \"QUIT :\"\\) ").match(str).hasMatch());
     str.clear();
 
     dbg << IrcCommand::Join;

--- a/tests/auto/ircconnection/tst_ircconnection.cpp
+++ b/tests/auto/ircconnection/tst_ircconnection.cpp
@@ -14,7 +14,6 @@
 #include "ircmessage.h"
 #include "ircfilter.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 #include <QtCore/QTextCodec>
 #include <QtCore/QScopedPointer>
 #ifndef QT_NO_SSL
@@ -1770,17 +1769,17 @@ void tst_IrcConnection::testDebug()
 
     IrcConnection connection;
     dbg << &connection;
-    QVERIFY(QRegExp("IrcConnection\\(0x[0-9A-Fa-f]+\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcConnection\\(0x[0-9A-Fa-f]+\\) ").match(str).hasMatch());
     str.clear();
 
     connection.setHost("irc.freenode.net");
     dbg << &connection;
-    QVERIFY(QRegExp("IrcConnection\\(0x[0-9A-Fa-f]+, irc.freenode.net\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcConnection\\(0x[0-9A-Fa-f]+, irc.freenode.net\\) ").match(str).hasMatch());
     str.clear();
 
     connection.setDisplayName("Freenode");
     dbg << &connection;
-    QVERIFY(QRegExp("IrcConnection\\(0x[0-9A-Fa-f]+, Freenode\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcConnection\\(0x[0-9A-Fa-f]+, Freenode\\) ").match(str).hasMatch());
     str.clear();
 
     dbg << IrcConnection::Connected;

--- a/tests/auto/irclagtimer/tst_irclagtimer.cpp
+++ b/tests/auto/irclagtimer/tst_irclagtimer.cpp
@@ -74,9 +74,9 @@ void tst_IrcLagTimer::testLag()
     QVERIFY(clientSocket->waitForBytesWritten(1000));
     QVERIFY(serverSocket->waitForReadyRead(1000));
 
-    QRegExp rx("PING communi/(\\d+)");
+    QRegularExpression rx("PING communi/(\\d+)");
     QString written = QString::fromUtf8(serverSocket->readAll());
-    QVERIFY(rx.indexIn(written) != -1);
+    QVERIFY(rx.match(written).hasMatch());
 
     waitForWritten(QString(":irc.ser.ver PONG communi communi/%1").arg(QDateTime::currentMSecsSinceEpoch() - 1234ll).toUtf8());
     QVERIFY(timer.lag() >= 1234ll);

--- a/tests/auto/ircmessage/tst_ircmessage.cpp
+++ b/tests/auto/ircmessage/tst_ircmessage.cpp
@@ -11,7 +11,6 @@
 #include "ircconnection.h"
 #include "ircprotocol.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 #include <QtCore/QTextCodec>
 #include <QtCore/QScopedPointer>
 
@@ -1166,27 +1165,27 @@ void tst_IrcMessage::testDebug()
 
     IrcMessage message(nullptr);
     dbg << &message;
-    QVERIFY(QRegExp("IrcMessage\\(0x[0-9A-Fa-f]+, flags=\\(None\\)\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcMessage\\(0x[0-9A-Fa-f]+, flags=\\(None\\)\\) ").match(str).hasMatch());
     str.clear();
 
     message.setObjectName("foo");
     dbg << &message;
-    QVERIFY(QRegExp("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(None\\)\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(None\\)\\) ").match(str).hasMatch());
     str.clear();
 
     message.setPrefix("nick!ident@host");
     dbg << &message;
-    QVERIFY(QRegExp("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(None\\), prefix=nick!ident@host\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(None\\), prefix=nick!ident@host\\) ").match(str).hasMatch());
     str.clear();
 
     message.setCommand("COMMAND");
     dbg << &message;
-    QVERIFY(QRegExp("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(None\\), prefix=nick!ident@host, command=COMMAND\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(None\\), prefix=nick!ident@host, command=COMMAND\\) ").match(str).hasMatch());
     str.clear();
 
     message.setFlags(IrcMessage::Own | IrcMessage::Playback | IrcMessage::Implicit);
     dbg << &message;
-    QVERIFY(QRegExp("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(Own\\|Playback\\|Implicit\\), prefix=nick!ident@host, command=COMMAND\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcMessage\\(0x[0-9A-Fa-f]+, name=foo, flags=\\(Own\\|Playback\\|Implicit\\), prefix=nick!ident@host, command=COMMAND\\) ").match(str).hasMatch());
     str.clear();
 
     dbg << IrcMessage::None;

--- a/tests/auto/ircnetwork/tst_ircnetwork.cpp
+++ b/tests/auto/ircnetwork/tst_ircnetwork.cpp
@@ -11,7 +11,6 @@
 #include "irccommand.h"
 #include "ircconnection.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 #include "tst_ircclientserver.h"
 #include "tst_ircdata.h"
 #ifdef Q_OS_LINUX
@@ -440,19 +439,19 @@ void tst_IrcNetwork::testDebug()
 
     IrcConnection connection;
     dbg << connection.network();
-    QVERIFY(QRegExp("IrcNetwork\\(0x[0-9A-Fa-f]+\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcNetwork\\(0x[0-9A-Fa-f]+\\) ").match(str).hasMatch());
     str.clear();
 
     connection.network()->setObjectName("obj");
     dbg << connection.network();
-    QVERIFY(QRegExp("IrcNetwork\\(0x[0-9A-Fa-f]+, name=obj\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcNetwork\\(0x[0-9A-Fa-f]+, name=obj\\) ").match(str).hasMatch());
     str.clear();
 
 #ifdef Q_OS_LINUX
     // others have problems with symbols (win) or private headers (osx frameworks)
     IrcNetworkPrivate::get(connection.network())->name = "net";
     dbg << connection.network();
-    QVERIFY(QRegExp("IrcNetwork\\(0x[0-9A-Fa-f]+, name=obj, network=net\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcNetwork\\(0x[0-9A-Fa-f]+, name=obj, network=net\\) ").match(str).hasMatch());
     str.clear();
 #endif // Q_OS_LINUX
 

--- a/tests/auto/ircuser/tst_ircuser.cpp
+++ b/tests/auto/ircuser/tst_ircuser.cpp
@@ -9,7 +9,6 @@
 
 #include "ircuser.h"
 #include <QtTest/QtTest>
-#include <QtCore/QRegExp>
 #ifdef Q_OS_LINUX
 #include "ircuser_p.h"
 #endif // Q_OS_LINUX
@@ -64,19 +63,19 @@ void tst_IrcUser::testDebug()
 
     IrcUser user;
     dbg << &user;
-    QVERIFY(QRegExp("IrcUser\\(0x[0-9A-Fa-f]+\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcUser\\(0x[0-9A-Fa-f]+\\) ").match(str).hasMatch());
     str.clear();
 
     user.setObjectName("obj");
     dbg << &user;
-    QVERIFY(QRegExp("IrcUser\\(0x[0-9A-Fa-f]+, name=obj\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcUser\\(0x[0-9A-Fa-f]+, name=obj\\) ").match(str).hasMatch());
     str.clear();
 
 #ifdef Q_OS_LINUX
     // others have problems with symbols (win) or private headers (osx frameworks)
     IrcUserPrivate::get(&user)->setName("usr");
     dbg << &user;
-    QVERIFY(QRegExp("IrcUser\\(0x[0-9A-Fa-f]+, name=obj, user=usr\\) ").exactMatch(str));
+    QVERIFY(QRegularExpression("IrcUser\\(0x[0-9A-Fa-f]+, name=obj, user=usr\\) ").match(str).hasMatch());
     str.clear();
 #endif // Q_OS_LINUX
 }


### PR DESCRIPTION
I'm looking into migrating my application using libcommuni to Qt6. In the new major version, `QRegExp` has been fully deprecated. While it can be used with Qt6 by importing hacky qt5compat module (which brings some old deprecated modules if needed), it's still good to update the code.

- Replaced QRegExp with QRegularExpression in tests
- Replace most QRegExp occurences with QRegularExpression

I've also noticed some old code there check for older version of Qt - I've looked up in changelog that is was added in `[3.1.0] - 2014-03-08` and figured that this check can be now removed, so I did just that.
