### PR TITLE
Ensure to only use #include <QTextCodec> to fix compilation on Qt6

### DIFF
--- a/include/IrcCore/ircmessagedecoder_p.h
+++ b/include/IrcCore/ircmessagedecoder_p.h
@@ -31,7 +31,7 @@
 
 #include <IrcGlobal>
 #include <QtCore/qbytearray.h>
-#include <QtCore/qtextcodec.h>
+#include <QTextCodec>
 
 IRC_BEGIN_NAMESPACE
 

--- a/tests/auto/irccommand/tst_irccommand.cpp
+++ b/tests/auto/irccommand/tst_irccommand.cpp
@@ -12,7 +12,7 @@
 #include "ircconnection.h"
 #include <QtTest/QtTest>
 #include <QtCore/QRegExp>
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 #include <QtCore/QScopedPointer>
 
 class tst_IrcCommand : public QObject

--- a/tests/auto/ircconnection/tst_ircconnection.cpp
+++ b/tests/auto/ircconnection/tst_ircconnection.cpp
@@ -15,7 +15,7 @@
 #include "ircfilter.h"
 #include <QtTest/QtTest>
 #include <QtCore/QRegExp>
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 #include <QtCore/QScopedPointer>
 #ifndef QT_NO_SSL
 #include <QtNetwork/QSslSocket>

--- a/tests/auto/ircmessage/tst_ircmessage.cpp
+++ b/tests/auto/ircmessage/tst_ircmessage.cpp
@@ -12,7 +12,7 @@
 #include "ircprotocol.h"
 #include <QtTest/QtTest>
 #include <QtCore/QRegExp>
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 #include <QtCore/QScopedPointer>
 
 #ifdef Q_OS_LINUX

--- a/tests/benchmarks/ircmessagedecoder/tst_ircmessagedecoder.cpp
+++ b/tests/benchmarks/ircmessagedecoder/tst_ircmessagedecoder.cpp
@@ -9,7 +9,7 @@
 
 #include "ircmessagedecoder_p.h"
 #include <QtTest/QtTest>
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 #include <QtCore/QStringList>
 
 static const QByteArray MSG_32_5("Vestibulum eu libero eget metus.");


### PR DESCRIPTION
`QTextCodec` has been removed from Qt6 and as per #100 I'd want to try to migrate it to something else if possible. But for now that may have turned out to be a bit more difficult to do, so for the short-term solution to building libcommuni with Qt6 is to use Qt5Compat module - to use it properly though format of includes has to be exactly `<QTextCodec>` since that class is no longer part of QtCore.

Optionally, most other includes, like `<QtCore/qbytearray.h>` could be simplified to just `<QByteArray>`, but I didn't want to make too many unrelated changes at once - can make those in a separate pull request if that's reasonable.