### PR TITLE
Last fixes for Qt6 port

### DIFF
--- a/src/core/ircmessage.cpp
+++ b/src/core/ircmessage.cpp
@@ -2088,7 +2088,7 @@ QString IrcWhoisMessage::address() const
 QDateTime IrcWhoisMessage::since() const
 {
     Q_D(const IrcMessage);
-    return QDateTime::fromTime_t(d->param(5).toInt());
+    return QDateTime::fromSecsSinceEpoch(d->param(5).toInt());
 }
 
 /*!

--- a/src/model/ircuser.cpp
+++ b/src/model/ircuser.cpp
@@ -26,6 +26,8 @@
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "ircchannel.h"
+#include "ircchannel_p.h"
 #include "ircuser.h"
 #include "ircuser_p.h"
 #include <qdebug.h>

--- a/src/util/irccommandparser.cpp
+++ b/src/util/irccommandparser.cpp
@@ -414,7 +414,11 @@ void IrcCommandParser::removeCommand(IrcCommand::Type type, const QString& synta
 {
     Q_D(IrcCommandParser);
     bool changed = false;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QMutableMultiMapIterator<QString, IrcCommandInfo> it(d->commands);
+#else
+    QMutableMapIterator<QString, IrcCommandInfo> it(d->commands);
+#endif
     while (it.hasNext()) {
         IrcCommandInfo cmd = it.next().value();
         if (cmd.type == type && (syntax.isEmpty() || !syntax.compare(cmd.fullSyntax(), Qt::CaseInsensitive))) {

--- a/src/util/irccommandparser.cpp
+++ b/src/util/irccommandparser.cpp
@@ -414,7 +414,7 @@ void IrcCommandParser::removeCommand(IrcCommand::Type type, const QString& synta
 {
     Q_D(IrcCommandParser);
     bool changed = false;
-    QMutableMapIterator<QString, IrcCommandInfo> it(d->commands);
+    QMutableMultiMapIterator<QString, IrcCommandInfo> it(d->commands);
     while (it.hasNext()) {
         IrcCommandInfo cmd = it.next().value();
         if (cmd.type == type && (syntax.isEmpty() || !syntax.compare(cmd.fullSyntax(), Qt::CaseInsensitive))) {

--- a/src/util/irctextformat.cpp
+++ b/src/util/irctextformat.cpp
@@ -145,8 +145,8 @@ static QString parseUrls(const QString& message, const QString& pattern, QList<Q
     while (it.hasNext()) {
         QRegularExpressionMatch match = it.next();
         QString protocol;
-        if (match.capturedRef(2).isEmpty()) {
-            QStringRef link = match.capturedRef(1);
+        if (match.capturedView(2).isEmpty()) {
+            QStringView link = match.capturedView(1);
             if (link.startsWith(QStringLiteral("ftp."), Qt::CaseInsensitive))
                 protocol = QStringLiteral("ftp://");
             else if (link.contains(QStringLiteral("@")))

--- a/src/util/irctextformat.cpp
+++ b/src/util/irctextformat.cpp
@@ -145,8 +145,13 @@ static QString parseUrls(const QString& message, const QString& pattern, QList<Q
     while (it.hasNext()) {
         QRegularExpressionMatch match = it.next();
         QString protocol;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+        if (match.capturedRef(2).isEmpty()) {
+            QStringRef link = match.capturedRef(1);
+#else
         if (match.capturedView(2).isEmpty()) {
             QStringView link = match.capturedView(1);
+#endif
             if (link.startsWith(QStringLiteral("ftp."), Qt::CaseInsensitive))
                 protocol = QStringLiteral("ftp://");
             else if (link.contains(QStringLiteral("@")))


### PR DESCRIPTION
Hopefully it's the last set of changes. Thanks for merging fixes so far :D

- `QDateTime::fromTime_t` has been replaced with `QDateTime::fromSecsSinceEpoch`, old method has been deprecated in Qt 5.8.
- had to include IrcChannel headers to prevent compilation error, see [compiler output](https://haste.zneix.eu/raw/ubatipufel)
- `QMutableMapIterator` no longer takes `QMultiMap` in initializer and had to be replaced with `QMutableMultiMapIterator`
- `QStringRef` no longer exists. It's recommended to use `QStringView` instead, according to [Qt Core changes update](https://doc-snapshots.qt.io/qt6-dev/qtcore-changes-qt6.html#the-qstringref-class)
