### PR TITLE
Don't reset connection count on connection close but on quit

### DIFF
--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -1398,7 +1398,6 @@ void IrcConnection::close()
         if (d->socket->state() == QAbstractSocket::UnconnectedState)
             d->setStatus(Closed);
         d->reconnecter.stop();
-        d->setConnectionCount(0);
     }
 }
 
@@ -1415,10 +1414,13 @@ void IrcConnection::close()
  */
 void IrcConnection::quit(const QString& reason)
 {
-    if (isConnected())
+    Q_D(IrcConnection);
+    if (isConnected()) {
+        d->setConnectionCount(0);
         sendCommand(IrcCommand::createQuit(reason));
-    else
+    } else {
         close();
+    }
 }
 
 /*!


### PR DESCRIPTION
The connection could be closed manually if the network configuration
changes if the user closes the connection intentionally he calls quit
directory or indirectionally.
So only set connection to 0 in this case.