### PR TITLE
Add an option to drop connections to IrcLagTimer

### DIFF
--- a/include/IrcCore/irccommand.h
+++ b/include/IrcCore/irccommand.h
@@ -86,7 +86,8 @@ public:
         Who,
         Whois,
         Whowas,
-        Monitor
+        Monitor,
+        ChathistoryLatest,
     };
 
     explicit IrcCommand(QObject* parent = nullptr);
@@ -112,6 +113,7 @@ public:
     Q_INVOKABLE static IrcCommand* createAway(const QString& reason = QString());
     Q_INVOKABLE static IrcCommand* createCapability(const QString& subCommand, const QString& capability);
     Q_INVOKABLE static IrcCommand* createCapability(const QString& subCommand, const QStringList& capabilities = QStringList());
+    Q_INVOKABLE static IrcCommand* createChathistoryLatest(const QString& target, const QDateTime &stamp, int limit);
     Q_INVOKABLE static IrcCommand* createCtcpAction(const QString& target, const QString& action);
     Q_INVOKABLE static IrcCommand* createCtcpReply(const QString& target, const QString& reply);
     Q_INVOKABLE static IrcCommand* createCtcpRequest(const QString& target, const QString& request);

--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -177,6 +177,7 @@ public Q_SLOTS:
     bool sendCommand(IrcCommand* command);
     bool sendData(const QByteArray& data);
     bool sendRaw(const QString& message);
+    bool requestHistory(const QString& buffer, const QDateTime& since, int limit = 1000);
 
 Q_SIGNALS:
     void connecting();

--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -169,6 +169,7 @@ public:
 public Q_SLOTS:
     void open();
     void close();
+    void reconnect();
     void quit(const QString& reason = QString());
     void setEnabled(bool enabled = true);
     void setDisabled(bool disabled = true);

--- a/include/IrcCore/ircmessage.h
+++ b/include/IrcCore/ircmessage.h
@@ -207,6 +207,7 @@ class IRC_CORE_EXPORT IrcBatchMessage : public IrcMessage
     Q_OBJECT
     Q_PROPERTY(QString tag READ tag)
     Q_PROPERTY(QString batch READ batch)
+    Q_PROPERTY(QString target READ target)
     Q_PROPERTY(QList<IrcMessage*> messages READ messages)
 
 public:
@@ -214,10 +215,12 @@ public:
 
     QString tag() const;
     QString batch() const;
+    QString target() const;
 
     QList<IrcMessage*> messages() const;
 
     bool isValid() const override;
+    bool isHistory() const;
 
 private:
     Q_DISABLE_COPY(IrcBatchMessage)

--- a/include/IrcModel/ircbuffer_p.h
+++ b/include/IrcModel/ircbuffer_p.h
@@ -62,6 +62,7 @@ public:
     bool isMonitorable() const;
 
     bool processMessage(IrcMessage* message);
+    bool requestHistory();
 
     virtual bool processAwayMessage(IrcAwayMessage* message);
     virtual bool processJoinMessage(IrcJoinMessage* message);
@@ -89,7 +90,7 @@ public:
     bool persistent = false;
     bool sticky = false;
     QVariantMap userData;
-    QDateTime activity;
+    QDateTime activity, latest;
     MonitorStatus monitorStatus = MonitorUnknown;
     IrcBuffer::Type type = IrcBuffer::Basic;
 };

--- a/include/IrcUtil/irclagtimer.h
+++ b/include/IrcUtil/irclagtimer.h
@@ -51,7 +51,7 @@ public:
     ~IrcLagTimer() override;
 
     IrcConnection* connection() const;
-    void setConnection(IrcConnection* connection);
+    void setConnection(IrcConnection* connection, bool autoreconnect = false);
 
     qint64 lag() const;
 
@@ -60,6 +60,7 @@ public:
 
 Q_SIGNALS:
     void lagChanged(qint64 lag);
+    void pongMissed();
 
 private:
     QScopedPointer<IrcLagTimerPrivate> d_ptr;

--- a/src/core/irc.cpp
+++ b/src/core/irc.cpp
@@ -116,7 +116,8 @@ QStringList Irc::supportedCapabilities()
                          << QLatin1String("multi-prefix")
                          << QLatin1String("sasl")
                          << QLatin1String("server-time")
-                         << QLatin1String("userhost-in-names");
+                         << QLatin1String("userhost-in-names")
+                         << QLatin1String("draft/chathistory");
 }
 
 /*!

--- a/src/core/irccommand.cpp
+++ b/src/core/irccommand.cpp
@@ -413,6 +413,8 @@ QString IrcCommand::toString() const
         case Admin:         return QString("ADMIN %1").arg(p0); // server
         case Away:          return QString("AWAY :%1").arg(d->params(0)); // reason
         case Capability:    return QString("CAP %1 :%2").arg(p0, d->params(1)); // subcmd, caps
+        case ChathistoryLatest:
+                            return QString("CHATHISTORY LATEST %1 %2 %3").arg(p0, p1, p2); // target, stamp/msgid, limit
         case CtcpAction:    return QString("PRIVMSG %1 :\1ACTION %2\1").arg(p0, d->params(1)); // target, msg
         case CtcpRequest:   return QString("PRIVMSG %1 :\1%2\1").arg(p0, d->params(1)); // target, msg
         case CtcpReply:     return QString("NOTICE %1 :\1%2\1").arg(p0, d->params(1)); // target, msg
@@ -502,6 +504,11 @@ IrcCommand* IrcCommand::createAway(const QString& reason)
 IrcCommand* IrcCommand::createCapability(const QString& subCommand, const QString& capability)
 {
     return createCapability(subCommand, QStringList() << capability);
+}
+
+IrcCommand* IrcCommand::createChathistoryLatest(const QString& target, const QDateTime& stamp, int limit)
+{
+    return IrcCommandPrivate::createCommand(ChathistoryLatest, QStringList() << target << "timestamp=" + stamp.toUTC().toString("yyyy-MM-dd'T'hh:mm:ss.zzz'Z'") << QString::number(limit));
 }
 
 /*!

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -1728,6 +1728,12 @@ void IrcConnection::setProtocol(IrcProtocol* proto)
     }
 }
 
+void IrcConnection::reconnect()
+{
+    Q_D(IrcConnection);
+    d->_irc_disconnected();
+}
+
 #ifndef QT_NO_DEBUG_STREAM
 QDebug operator<<(QDebug debug, IrcConnection::Status status)
 {

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -381,6 +381,7 @@ void IrcConnectionPrivate::open()
     if (q->isActive()) {
         pendingOpen = true;
     } else {
+        q->close();
         closed = false;
         if (!servers.isEmpty()) {
             QString h; int p; bool s;

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -1507,6 +1507,19 @@ bool IrcConnection::sendRaw(const QString& message)
     return sendData(message.toUtf8());
 }
 
+bool IrcConnection::requestHistory(const QString& buffer, const QDateTime& since, int limit)
+{
+    Q_D(IrcConnection);
+
+    if (d->network->activeCapabilities().contains("draft/chathistory"))
+    {
+        sendCommand(IrcCommand::createChathistoryLatest(buffer, since, limit));
+        return true;
+    }
+
+    return false;
+}
+
 /*!
     Installs a message \a filter on the connection. The \a filter must implement the IrcMessageFilter interface.
 

--- a/src/core/ircmessage.cpp
+++ b/src/core/ircmessage.cpp
@@ -922,6 +922,14 @@ QString IrcBatchMessage::batch() const
     return d->param(1);
 }
 
+QString IrcBatchMessage::target() const
+{
+    if (isHistory())
+        return parameters().value(2);
+    else
+        return "";
+}
+
 /*!
     This property holds the list of batched messages.
 
@@ -937,6 +945,11 @@ QList<IrcMessage*> IrcBatchMessage::messages() const
 bool IrcBatchMessage::isValid() const
 {
     return IrcMessage::isValid() && !batch().isEmpty();
+}
+
+bool IrcBatchMessage::isHistory() const
+{
+    return batch() == "znc.in/playback" || batch() == "chathistory";
 }
 
 /*!

--- a/src/model/ircbuffer.cpp
+++ b/src/model/ircbuffer.cpp
@@ -166,9 +166,13 @@ bool IrcBufferPrivate::processMessage(IrcMessage* message)
 {
     Q_Q(IrcBuffer);
     bool processed = false;
+
     switch (message->type()) {
     case IrcMessage::Away:
         processed = processAwayMessage(static_cast<IrcAwayMessage*>(message));
+        break;
+    case IrcMessage::Batch:
+        processed = static_cast<IrcBatchMessage*>(message)->isHistory();
         break;
     case IrcMessage::Join:
         processed = processJoinMessage(static_cast<IrcJoinMessage*>(message));

--- a/src/model/ircbuffermodel.cpp
+++ b/src/model/ircbuffermodel.cpp
@@ -188,6 +188,14 @@ bool IrcBufferModelPrivate::messageFilter(IrcMessage* msg)
             processed = processMessage(static_cast<IrcModeMessage*>(msg)->target(), msg);
             break;
 
+        case IrcMessage::Batch:
+        {
+            IrcBatchMessage* batch = static_cast<IrcBatchMessage*>(msg);
+            if (batch->isHistory())
+                processed = processMessage(batch->target(), msg, true);
+            break;
+        }
+
         case IrcMessage::Numeric:
             // TODO: any other special cases besides RPL_NAMREPLY?
             if (static_cast<IrcNumericMessage*>(msg)->code() == Irc::RPL_NAMREPLY) {

--- a/src/model/ircchannel.cpp
+++ b/src/model/ircchannel.cpp
@@ -371,6 +371,7 @@ bool IrcChannelPrivate::processJoinMessage(IrcJoinMessage* message)
         if (message->isOwn()) {
             setActive(true);
             enabled = true;
+            requestHistory();
         } else {
             addUser(message->nick());
         }


### PR DESCRIPTION
It makes sense to drop a (sufficiently) dead connection, so make that easy. It would also allow a simple workaround for sailfish-communi missing connection events and getting stuck forever. I'll send a draft PR for the sailfish-communi half of this in a bit.