### PR TITLE
src: Use errorOccurred instead of error signal

### DIFF
--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -1162,7 +1162,11 @@ void IrcConnection::setSocket(QAbstractSocket* socket)
             connect(socket, SIGNAL(connected()), this, SLOT(_irc_connected()));
             connect(socket, SIGNAL(disconnected()), this, SLOT(_irc_disconnected()));
             connect(socket, SIGNAL(readyRead()), this, SLOT(_irc_readData()));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+            connect(socket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this, SLOT(_irc_error(QAbstractSocket::SocketError)));
+#else
             connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(_irc_error(QAbstractSocket::SocketError)));
+#endif
             connect(socket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(_irc_state(QAbstractSocket::SocketState)));
             if (isSecure())
                 connect(socket, SIGNAL(sslErrors(QList<QSslError>)), this, SLOT(_irc_sslErrors()));


### PR DESCRIPTION
The [`QAbstractSocket::errorOccurred` signal was marked as obsolete](https://doc.qt.io/qt-5/qabstractsocket-obsolete.html#error-1) in Qt 5.15, and removed in Qt 6. The [`QAbstractSocket::errorOccurred`](https://doc.qt.io/qt-6/qabstractsocket.html#errorOccurred) signal should be used instead.

This PR adds a check that uses the new signal if the Qt version is 5.15 and up.